### PR TITLE
Staff search/exact approx matching

### DIFF
--- a/home/src/Controller/Component/StaffSearchComponent.php
+++ b/home/src/Controller/Component/StaffSearchComponent.php
@@ -71,6 +71,10 @@ class StaffSearchComponent extends Component
 
 		  $query = array();
 		  $query['q'] = (!empty($name)) ? urlencode( implode(' ', $name) ) : '';
+			// we need to URL encode the string of course
+			// but the mobile oxford API expects initial and surname separated by space e.g. 'f birnie'
+			// URL encoding the string puts a + instead of a space so replace it
+			$query['q'] = str_replace('+',' ',$query['q']);
 
 		  if (!empty($fields['medium']))  $query['medium'] = $fields['medium'];
 		  if (!empty($fields['match']))   $query['match'] = $fields['match'];

--- a/htdocs/css/StaffSearch/style.css
+++ b/htdocs/css/StaffSearch/style.css
@@ -19,7 +19,6 @@ button.emergency-numbers:hover{background-color:#c8193e}
 .staff_search_jsonly_contact_form .name-details div:first-child{flex-grow:4;padding:0;margin:0}
 .staff_search_jsonly_contact_form .name-details div:last-child{flex-grow:1;padding:0;margin:0 0 0 3%;max-width:5em}
 .staff_search_jsonly_contact_form button{text-transform:uppercase}
-#wrapper-main .webform-client-form .staff_search_jsonly_contact_form #exact_wrapper.radio{display:none}
 #wrapper-main .paragraphs-item-form .webform-client-form .staff_search_jsonly_contact_form button:not(.emergency-numbers){background-color:#44687d;border-color:#44687d}
 #wrapper-main .paragraphs-item-form .webform-client-form .staff_search_jsonly_contact_form button:not(.emergency-numbers):hover{background-color:#4e7891;border-color:#4e7891}
 #wrapper-main .webform-client-form .staff_search_jsonly_contact_form .webform-component{margin-bottom:0}


### PR DESCRIPTION
The non-JS version didn't get any results from the end point because it expects a space-separated "q" param and it was separated by a +.

The exact/approximate radio buttons were just being hidden by a CSS rule.